### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Test and Deploy
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/matushorvath/aoc-bot/security/code-scanning/9](https://github.com/matushorvath/aoc-bot/security/code-scanning/9)

To fix this error, we should add an explicit `permissions` block to the workflow file (.github/workflows/build.yml). This block can be set at the root to apply to all jobs, or at the individual job level. Since none of the jobs appear to need write access to repository contents (they only check out code, run tests, report coverage, install packages, and deploy with AWS credentials), we can start with the minimal recommended permissions: `contents: read`. If specific steps (like coverage report or deployment) require more, only those jobs or steps should be granted broader permissions. In this case, the minimal permissions block can be set at the root of the workflow to cover all jobs; if future jobs need more (e.g., pull-request: write), this can be added at the job level.

**Changes required:**
- Insert a root-level `permissions:` block immediately after (or before) the `on:` block at the top of `.github/workflows/build.yml`.
- Set `contents: read` as the starting point.
- No extra imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
