### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,5 @@
 name: Integration Tests
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/matushorvath/aoc-bot/security/code-scanning/8](https://github.com/matushorvath/aoc-bot/security/code-scanning/8)

To fix this problem, add an explicit `permissions` block to the workflow, either at the root level (to affect all jobs) or at the job level (to affect only the `test` job). Given that there is only one job and its actions are limited to checking out code and running tests, the best way is to set `permissions: contents: read` at the workflow root level. This limits the GITHUB_TOKEN to only reading repository contents, minimizing its scope, and adheres to the principle of least privilege. Add the following block below the `name` entry and above `on` (so it applies to all jobs):

```yaml
permissions:
  contents: read
```

No imports or further definitions are needed; this is a native YAML configuration for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
